### PR TITLE
Clear R CMD CHECK problems

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
 ^README\.Rmd$
+^README\.html$
 ^LICENSE\.md$
 ^rawdata

--- a/R/glm_fixit.R
+++ b/R/glm_fixit.R
@@ -153,15 +153,15 @@
 #' @return This function returns an object class "glm_fixit"
 #' @seealso [research_data]
 #' @examples
+#' \donttest{
 #' ## Confusion matrix
 #' table(val_data$w, val_data$x)
 #' ## default
 #' glm_fixit(y ~ x || w + z, data = research_data, data2 = val_data)
-#' ## a more accurate correction
-#' glm_fixit(y ~ x || w + z, data = research_data, data2 = val_data,
-#' proxy_formula = w ~ x*w*z, truth_formula = x ~ w)
 #' ## proxy variable in the outcome
-#' glm_fixit(y || w ~ x + z, data = research_data2, data2 = val_data2)
+#' glm_fixit(y || w ~ x + z, data = research_data2,
+#' data2 = val_data2, family = binomial("logit"))
+#' }
 #' @importFrom stats binomial coef confint dnorm gaussian glm model.frame model.matrix optim plogis qnorm rnorm
 #' @export
 glm_fixit <- function(formula, family = gaussian(), data, data2, proxy_formula = NULL, proxy_family=binomial(link='logit'), truth_formula = NULL, truth_family=binomial(link='logit'), maxit = 1e6, method = 'L-BFGS-B') {

--- a/R/likelihoods.R
+++ b/R/likelihoods.R
@@ -2,13 +2,13 @@ ll.logistic <- function(outcome, model.params, model.matrix) {
     ll <- vector(mode='numeric', length=length(outcome))
     ##print(model.params)
     ##print(dim(model.matrix))
-    ll[outcome == 1] <- plogis(model.params %*% t(model.matrix[outcome==1,]), log=TRUE)
-    ll[outcome == 0] <- plogis(model.params %*% t(model.matrix[outcome==0,]), log=TRUE, lower.tail=FALSE)
+    ll[outcome == 1] <- plogis(model.params %*% t(model.matrix[outcome==1,]), log.p = TRUE)
+    ll[outcome == 0] <- plogis(model.params %*% t(model.matrix[outcome==0,]), log.p = TRUE, lower.tail=FALSE)
     return(ll)
 }
 
 # sigma is always the last model parameter
 ll.gaussian <- function(outcome, model.params, model.matrix) {
     ll <- vector(mode='numeric', length=length(outcome))
-    ll[outcome == 1] <- dnorm(outcome, model.params[1:(length(model.params)-1)] %*% t(model.matrix), sd = model.params[length(model.params)], log=TRUE)
+    ll[outcome == 1] <- dnorm(outcome, model.params[1:(length(model.params)-1)] %*% t(model.matrix), sd = model.params[length(model.params)], log = TRUE)
 }

--- a/man/glm_fixit.Rd
+++ b/man/glm_fixit.Rd
@@ -45,15 +45,15 @@ This function returns an object class "glm_fixit"
 This function provides the MLE-based misclassification correction method proposed by Carroll.
 }
 \examples{
+\donttest{
 ## Confusion matrix
 table(val_data$w, val_data$x)
 ## default
 glm_fixit(y ~ x || w + z, data = research_data, data2 = val_data)
-## a more accurate correction
-glm_fixit(y ~ x || w + z, data = research_data, data2 = val_data,
-proxy_formula = w ~ x*w*z, truth_formula = x ~ w)
 ## proxy variable in the outcome
-glm_fixit(y || w ~ x + z, data = research_data2, data2 = val_data2)
+glm_fixit(y || w ~ x + z, data = research_data2,
+data2 = val_data2, family = binomial("logit"))
+}
 }
 \seealso{
 \link{research_data}

--- a/man/research_data.Rd
+++ b/man/research_data.Rd
@@ -53,15 +53,15 @@ For this pair of datasets, we are interested in the relationship between \code{x
 }
 }
 \examples{
+\donttest{
 ## Confusion matrix
 table(val_data$w, val_data$x)
 ## default
 glm_fixit(y ~ x || w + z, data = research_data, data2 = val_data)
-## a more accurate correction
-glm_fixit(y ~ x || w + z, data = research_data, data2 = val_data,
-proxy_formula = w ~ x*w*z, truth_formula = x ~ w)
 ## proxy variable in the outcome
-glm_fixit(y || w ~ x + z, data = research_data2, data2 = val_data2)
+glm_fixit(y || w ~ x + z, data = research_data2,
+data2 = val_data2, family = binomial("logit"))
+}
 }
 \seealso{
 \code{\link[=glm_fixit]{glm_fixit()}}


### PR DESCRIPTION
* the examples in `glm_fixit` takes more than 5s to run; CRAN will complain, put them in a `donttest` block
* remove the 2nd example - it emits too many warning messages
* fix the 3rd example - outcome variable with misc. but with gaussian
* remove the partial matching of `plogis` in the likelihood estimator

With these modifications, R CMD check gives no errors / warnings